### PR TITLE
Support operations on self-serve agents

### DIFF
--- a/selfserve-inventory.sh
+++ b/selfserve-inventory.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -eu
+
+# where root of puppet again checkout is
+PUPPET_AGAIN=${PUPPET_AGAIN:-../puppet}
+# node def relative to $PUPPET_AGAIN
+PUPPET_NODES=${PUPPET_NODES:-manifests/moco-nodes.pp}
+
+NODE_PATH=$PUPPET_AGAIN/$PUPPET_NODES
+
+warn() { for m; do echo "$m"; done 1>&2 ; }
+die() { warn "$@" ; exit 1; }
+usage() { warn "$@" "${USAGE:-}"; test $# -eq 0 ; exit $?; }
+
+if ! test -r $NODE_PATH; then
+    usage "Can't read $PUPPET_NODES under $PUPPET_AGAIN" \
+        "set 'PUPPET_AGAIN' to your local checkout"
+fi
+
+# one liner to get nodes, piped into subshell to JSONify it
+grep -B 12 selfserve_agent $NODE_PATH | grep -w node | cut -d\" -f2 |
+(
+    cat <<EOF
+{
+    "selfserve_agents": [
+EOF
+    leader="      "
+    while read node; do
+        echo "${leader}\"$node\""
+        leader="    , "
+    done
+    cat <<EOF
+    ]
+}
+EOF
+) # subshell end
+

--- a/selfserve.yml
+++ b/selfserve.yml
@@ -1,0 +1,41 @@
+---
+- name: Self Serve Hosts
+  hosts: selfserve_agents
+  vars:
+    action: "{{ lookup('env','action') }}"
+  become: true
+  user: "{{ lookup('env','MOZ_USER') | default(lookup('env', 'USER'), true) }}"
+  tasks:
+      - name: Stop selfserve_agents
+        supervisorctl:
+          name: selfserve-agent
+          state: stopped
+        when:
+            action == "stop"
+
+      - name: Start selfserve_agents
+        supervisorctl:
+          name: selfserve-agent
+          state: started
+        when:
+            action == "start"
+
+      - name: get status of selfserve_agents
+        command: supervisorctl status selfserve-agent
+        register: status
+        changed_when: false
+        when:
+          action == "status"
+
+      - name: Display status
+        debug: msg={{ status.stdout.split('\n') }}
+        when:
+          action == "status"
+
+      - name: Usage error
+        fail: msg="Specify an action of start, stop, status via -e"
+        when:
+          - action != "start"
+          - action != "stop"
+          - action != "status"
+

--- a/selfserve.yml
+++ b/selfserve.yml
@@ -13,6 +13,13 @@
         when:
             action == "stop"
 
+      - name: Restart selfserve_agents
+        supervisorctl:
+          name: selfserve-agent
+          state: restarted
+        when:
+            action == "restart"
+
       - name: Start selfserve_agents
         supervisorctl:
           name: selfserve-agent
@@ -33,9 +40,10 @@
           action == "status"
 
       - name: Usage error
-        fail: msg="Specify an action of start, stop, status via -e"
+        fail: msg="Specify an action of start, stop, restart, status via -e"
         when:
+          - action != "restart"
           - action != "start"
-          - action != "stop"
           - action != "status"
+          - action != "stop"
 


### PR DESCRIPTION
These need to be stopped during a DB failover (or restarted after a DB failover).